### PR TITLE
Label printing with error reporting

### DIFF
--- a/lib/hackru_service.dart
+++ b/lib/hackru_service.dart
@@ -59,16 +59,18 @@ Future<List<String>> events() async {
 
 Future<String> labelUrl() async {
   var response = await getMisc("/label-url.txt");
-  return response.body;
+  // In case there is a newline character at the end, remove it (there was before)
+  return response.body.replaceAll("\n", "");
 }
 
 void printLabel(String email, [String url]) async {
   if (url == null) {
     url = await labelUrl();
   }
-  print(url);
-  print(email);
-  //void response = http.get(url+email);
+  var response = await client.post(url, headers: {"Content-Type": "application/json"}, body: "{\"email\": \"$email\"}");
+  if (response.statusCode != 200) {
+    throw LabelPrintingError();
+  }
 }
 
 Future<List<HelpResource>> helpResources() async {

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -138,3 +138,8 @@ class UpdateError implements Exception {
   String errorMessage() => "Failed to update user: $lcsMessage";
   String toString() => errorMessage();
 }
+
+class LabelPrintingError implements Exception {
+  String errorMessage() => "Error printing label!";
+  String toString() => errorMessage();
+}

--- a/lib/screens/scanner2.dart
+++ b/lib/screens/scanner2.dart
@@ -357,17 +357,17 @@ class _QRScanner2State extends State<QRScanner2> {
     try {
       if(email != null) {
         user = await getUser(QRScanner2.cred, email);
-        print("here2");
         if (!user.dayOf.containsKey(QRScanner2.event) ||
             user.dayOf[QRScanner2.event] == false) {
           updateUserDayOf(QRScanner2.cred, user, QRScanner2.event);
           print(user);
-          if (QRScanner2.event == "checkIn") {
-            await print(user);
-          }
           result = "SCANNED!";
         } else {
           result = 'ALREADY SCANNED!';
+        }
+        if (QRScanner2.event == "checkIn") {
+          await printLabel(email);
+          result = "SCANNED!";
         }
       } else {
         print("attempt to scan null");
@@ -380,6 +380,8 @@ class _QRScanner2State extends State<QRScanner2> {
       result = 'NO SUCH USER';
     } on LcsError {
       result = 'LCS ERROR';
+    } on LabelPrintingError {
+      result = "ERROR PRINTING LABEL";
     } on ArgumentError catch(e){
       result = 'UNEXPECTED ERROR';
       print(result);


### PR DESCRIPTION
Fixes #8  

I implemented the `printLabel()` function in `hackru_service.dart` as well as a custom exception called `LabelPrintingError` that is thrown when the status code of the response from the printing endpoint is not 200. 

The scanner (`scanner2.dart`) calls `printLabel()` after scanning if checkin is selected. If a `LabelPrintingError` is thrown, it is caught and reported to the user by changing the `result` variable in the `_lcsHandel` function.