### PR TITLE
Loading indicator

### DIFF
--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -105,6 +105,19 @@ class Login extends StatelessWidget {
                     borderRadius: BorderRadius.all(Radius.circular(3.0)),
                   ),
                   onPressed: () async {
+                    // Show a dialog with a loading animation
+                    showDialog(
+                      barrierDismissible: false,
+                      context: context,
+                      builder: (BuildContext context, {barrierDismissible: false}){
+                        return new AlertDialog(backgroundColor: bluegrey_dark,
+                          title: Center(
+                            child: new CircularProgressIndicator(
+                            valueColor: AlwaysStoppedAnimation(mintgreen_light), strokeWidth: 3.0,),
+                          ),
+                        );
+                      }
+                    );
                     try {
                       var cred = await login(_emailController.text, _passwordController.text);
                       var user = await getUser(cred, _emailController.text);
@@ -113,6 +126,8 @@ class Login extends StatelessWidget {
                       QRScanner2.userEmail = _emailController.text;
                       QRScanner2.userPassword = _passwordController.text;
                       print(user);
+                      // Dismiss the loading dialog
+                      Navigator.pop(context);
                       if(user.role["director"] == true ){
                         Navigator.push(context, MaterialPageRoute(builder: (context) => AdminPage()),);
                       }
@@ -120,6 +135,8 @@ class Login extends StatelessWidget {
                         Navigator.push(context, MaterialPageRoute(builder: (context) => MyHomePage()),);
                       }
                     } on LcsLoginFailed catch (e) {
+                      // Dismiss the loading dialog
+                      Navigator.pop(context);
                       showDialog<void>(context: context, barrierDismissible: false,
                         builder: (BuildContext context) {
                           return AlertDialog(backgroundColor: bluegrey_dark,

--- a/lib/screens/scanner2.dart
+++ b/lib/screens/scanner2.dart
@@ -314,6 +314,18 @@ class _QRScanner2State extends State<QRScanner2> {
           backgroundColor: bluegrey,
           onPressed: () async {
             print("---------------scan button pressed ---------------------");
+            showDialog(
+                barrierDismissible: false,
+                context: context,
+                builder: (BuildContext context, {barrierDismissible: false}){
+                  return new AlertDialog(backgroundColor: bluegrey_dark,
+                    title: Center(
+                      child: new CircularProgressIndicator(
+                        valueColor: AlwaysStoppedAnimation(mintgreen_light), strokeWidth: 3.0,),
+                    ),
+                  );
+                }
+            );
             var _barcodeString = await new QRCodeReader()
                 .setAutoFocusIntervalInMs(200)
                 .setForceAutoFocus(true)
@@ -322,10 +334,26 @@ class _QRScanner2State extends State<QRScanner2> {
                 .setExecuteAfterPermissionGranted(true)
                 .scan();
             print("processing _barcodeString");
+            showDialog(
+                barrierDismissible: false,
+                context: context,
+                builder: (BuildContext context, {barrierDismissible: false}){
+                  return new AlertDialog(backgroundColor: bluegrey_dark,
+                    title: Center(
+                      child: new CircularProgressIndicator(
+                        valueColor: AlwaysStoppedAnimation(mintgreen_light), strokeWidth: 3.0,),
+                    ),
+                  );
+                }
+            );
             if(popup) {
               var message = await _lcsHandle(_barcodeString);
+              Navigator.pop(context);
+              Navigator.pop(context);
               _scanDialog(message);
             } else {
+              Navigator.pop(context);
+              Navigator.pop(context);
               setState(() {
                 _message = _lcsHandle(_barcodeString);
               });


### PR DESCRIPTION
Fixes #12 

When the user clicks log in and when an organizer scans a barcode, a dialog now shows up that is non-dismissable that contains the same loading indicator animation that we use for the announcements page. This loading indicator dialog is then dismissed automatically when the network request/computation is done.

