### PR TITLE
Prepare for android release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,12 +37,11 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "org.hackru.hackruflutter"
+        applicationId "org.hackru.oneapp.hackru"
         minSdkVersion 21
         targetSdkVersion 27
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode 12
+        versionName '3.0.0'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.hackru.hackruflutter">
+    package="org.hackru.oneapp.hackru">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/android/app/src/main/kotlin/org/hackru/oneapp/hackru/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/hackru/oneapp/hackru/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.hackru.hackruflutter
+package org.hackru.oneapp.hackru
 
 import android.os.Bundle
 


### PR DESCRIPTION
Changed these three things so that the play store will accept the flutter app as an update to the current android app:

1. Change the package name from `org.hackru.hackruflutter` to `org.hackru.oneapp.hackru` since the latter is the package name of the current app on the play store and it won't allow us to update the current app if the new version has a different package name.
2. Set the `versionCode` variable in the app level `build.gradle` to 12. The `versionCode` needs to be an integer that is higher than the last version's `versionCode`. The last version's `versionCode` is 11, so I set the flutter app's `versionCode` to 12.
3. Set the `versionName` to "3.0.0". This can be any string, but it should be some sort of semantic versioning. I'm not sure what the version name of the iOS app is. Maybe we should coordinate and choose the same version name between Android and iOS.